### PR TITLE
Allow sensitive datatype for passwords and added parameter password_h…

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,7 +715,7 @@ elasticsearch::user { 'myuser':
 }
 ```
 
-The `password` parameter will also accept password hashes generated from the `esusers`/`users` utility and ensure the password is kept in-sync with the Shield `users` file for all Elasticsearch instances.
+The `password` parameter does not accept hashes. Use parameter password_hash instead, generated from the `esusers`/`users` utility and ensure the password is kept in-sync with the Shield `users` file for all Elasticsearch instances.
 
 ```puppet
 elasticsearch::user { 'myuser':

--- a/manifests/index.pp
+++ b/manifests/index.pp
@@ -43,17 +43,17 @@
 # @author Tyler Langlois <tyler.langlois@elastic.co>
 #
 define elasticsearch::index (
-  Enum['absent', 'present']      $ensure                  = 'present',
-  Optional[String]               $api_basic_auth_password = $elasticsearch::api_basic_auth_password,
-  Optional[String]               $api_basic_auth_username = $elasticsearch::api_basic_auth_username,
-  Optional[Stdlib::Absolutepath] $api_ca_file             = $elasticsearch::api_ca_file,
-  Optional[Stdlib::Absolutepath] $api_ca_path             = $elasticsearch::api_ca_path,
-  String                         $api_host                = $elasticsearch::api_host,
-  Integer[0, 65535]              $api_port                = $elasticsearch::api_port,
-  Enum['http', 'https']          $api_protocol            = $elasticsearch::api_protocol,
-  Integer                        $api_timeout             = $elasticsearch::api_timeout,
-  Hash                           $settings                = {},
-  Boolean                        $validate_tls            = $elasticsearch::validate_tls,
+  Enum['absent', 'present']            $ensure                  = 'present',
+  Optional[Variant[String, Sensitive]] $api_basic_auth_password = $elasticsearch::api_basic_auth_password,
+  Optional[String]                     $api_basic_auth_username = $elasticsearch::api_basic_auth_username,
+  Optional[Stdlib::Absolutepath]       $api_ca_file             = $elasticsearch::api_ca_file,
+  Optional[Stdlib::Absolutepath]       $api_ca_path             = $elasticsearch::api_ca_path,
+  String                               $api_host                = $elasticsearch::api_host,
+  Integer[0, 65535]                    $api_port                = $elasticsearch::api_port,
+  Enum['http', 'https']                $api_protocol            = $elasticsearch::api_protocol,
+  Integer                              $api_timeout             = $elasticsearch::api_timeout,
+  Hash                                 $settings                = {},
+  Boolean                              $validate_tls            = $elasticsearch::validate_tls,
 ) {
 
   es_instance_conn_validator { "${name}-index-conn-validator":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -305,7 +305,7 @@
 #
 class elasticsearch (
   Enum['absent', 'present']                       $ensure,
-  Optional[String]                                $api_basic_auth_password,
+  Optional[Variant[String, Sensitive]]            $api_basic_auth_password,
   Optional[String]                                $api_basic_auth_username,
   Optional[String]                                $api_ca_file,
   Optional[String]                                $api_ca_path,

--- a/manifests/license.pp
+++ b/manifests/license.pp
@@ -46,18 +46,18 @@
 # @author Tyler Langlois <tyler.langlois@elastic.co>
 #
 class elasticsearch::license (
-  Enum['absent', 'present']          $ensure                  = 'present',
-  Optional[String]                   $api_basic_auth_password = $elasticsearch::api_basic_auth_password,
-  Optional[String]                   $api_basic_auth_username = $elasticsearch::api_basic_auth_username,
-  Optional[Stdlib::Absolutepath]     $api_ca_file             = $elasticsearch::api_ca_file,
-  Optional[Stdlib::Absolutepath]     $api_ca_path             = $elasticsearch::api_ca_path,
-  String                             $api_host                = $elasticsearch::api_host,
-  Integer[0, 65535]                  $api_port                = $elasticsearch::api_port,
-  Enum['http', 'https']              $api_protocol            = $elasticsearch::api_protocol,
-  Integer                            $api_timeout             = $elasticsearch::api_timeout,
-  Variant[String, Hash]              $content                 = $elasticsearch::license,
-  Optional[Enum['shield', 'x-pack']] $security_plugin         = $elasticsearch::security_plugin,
-  Boolean                            $validate_tls            = $elasticsearch::validate_tls,
+  Enum['absent', 'present']            $ensure                  = 'present',
+  Optional[Variant[String, Sensitive]] $api_basic_auth_password = $elasticsearch::api_basic_auth_password,
+  Optional[String]                     $api_basic_auth_username = $elasticsearch::api_basic_auth_username,
+  Optional[Stdlib::Absolutepath]       $api_ca_file             = $elasticsearch::api_ca_file,
+  Optional[Stdlib::Absolutepath]       $api_ca_path             = $elasticsearch::api_ca_path,
+  String                               $api_host                = $elasticsearch::api_host,
+  Integer[0, 65535]                    $api_port                = $elasticsearch::api_port,
+  Enum['http', 'https']                $api_protocol            = $elasticsearch::api_protocol,
+  Integer                              $api_timeout             = $elasticsearch::api_timeout,
+  Variant[String, Hash]                $content                 = $elasticsearch::license,
+  Optional[Enum['shield', 'x-pack']]   $security_plugin         = $elasticsearch::security_plugin,
+  Boolean                              $validate_tls            = $elasticsearch::validate_tls,
 ) {
   if $content =~ String {
     $_content = parsejson($content)

--- a/manifests/pipeline.pp
+++ b/manifests/pipeline.pp
@@ -45,17 +45,17 @@
 # @author Tyler Langlois <tyler.langlois@elastic.co>
 #
 define elasticsearch::pipeline (
-  Enum['absent', 'present']      $ensure                  = 'present',
-  Optional[String]               $api_basic_auth_password = $elasticsearch::api_basic_auth_password,
-  Optional[String]               $api_basic_auth_username = $elasticsearch::api_basic_auth_username,
-  Optional[Stdlib::Absolutepath] $api_ca_file             = $elasticsearch::api_ca_file,
-  Optional[Stdlib::Absolutepath] $api_ca_path             = $elasticsearch::api_ca_path,
-  String                         $api_host                = $elasticsearch::api_host,
-  Integer[0, 65535]              $api_port                = $elasticsearch::api_port,
-  Enum['http', 'https']          $api_protocol            = $elasticsearch::api_protocol,
-  Integer                        $api_timeout             = $elasticsearch::api_timeout,
-  Hash                           $content                 = {},
-  Boolean                        $validate_tls            = $elasticsearch::validate_tls,
+  Enum['absent', 'present']            $ensure                  = 'present',
+  Optional[Variant[String, Sensitive]] $api_basic_auth_password = $elasticsearch::api_basic_auth_password,
+  Optional[String]                     $api_basic_auth_username = $elasticsearch::api_basic_auth_username,
+  Optional[Stdlib::Absolutepath]       $api_ca_file             = $elasticsearch::api_ca_file,
+  Optional[Stdlib::Absolutepath]       $api_ca_path             = $elasticsearch::api_ca_path,
+  String                               $api_host                = $elasticsearch::api_host,
+  Integer[0, 65535]                    $api_port                = $elasticsearch::api_port,
+  Enum['http', 'https']                $api_protocol            = $elasticsearch::api_protocol,
+  Integer                              $api_timeout             = $elasticsearch::api_timeout,
+  Hash                                 $content                 = {},
+  Boolean                              $validate_tls            = $elasticsearch::validate_tls,
 ) {
 
   es_instance_conn_validator { "${name}-ingest-pipeline":

--- a/manifests/snapshot_repository.pp
+++ b/manifests/snapshot_repository.pp
@@ -60,22 +60,22 @@
 # @author Tyler Langlois <tyler.langlois@elastic.co>
 #
 define elasticsearch::snapshot_repository (
-  String                          $location,
-  Enum['absent', 'present']       $ensure                  = 'present',
-  Optional[String]                $api_basic_auth_password = $elasticsearch::api_basic_auth_password,
-  Optional[String]                $api_basic_auth_username = $elasticsearch::api_basic_auth_username,
-  Optional[Stdlib::Absolutepath]  $api_ca_file             = $elasticsearch::api_ca_file,
-  Optional[Stdlib::Absolutepath]  $api_ca_path             = $elasticsearch::api_ca_path,
-  String                          $api_host                = $elasticsearch::api_host,
-  Integer[0, 65535]               $api_port                = $elasticsearch::api_port,
-  Enum['http', 'https']           $api_protocol            = $elasticsearch::api_protocol,
-  Integer                         $api_timeout             = $elasticsearch::api_timeout,
-  Boolean                         $compress                = true,
-  Optional[String]                $chunk_size              = undef,
-  Optional[String]                $max_restore_rate        = undef,
-  Optional[String]                $max_snapshot_rate       = undef,
-  Optional[String]                $repository_type         = undef,
-  Boolean                         $validate_tls            = $elasticsearch::validate_tls,
+  String                               $location,
+  Enum['absent', 'present']            $ensure                  = 'present',
+  Optional[Variant[String, Sensitive]] $api_basic_auth_password = $elasticsearch::api_basic_auth_password,
+  Optional[String]                     $api_basic_auth_username = $elasticsearch::api_basic_auth_username,
+  Optional[Stdlib::Absolutepath]       $api_ca_file             = $elasticsearch::api_ca_file,
+  Optional[Stdlib::Absolutepath]       $api_ca_path             = $elasticsearch::api_ca_path,
+  String                               $api_host                = $elasticsearch::api_host,
+  Integer[0, 65535]                    $api_port                = $elasticsearch::api_port,
+  Enum['http', 'https']                $api_protocol            = $elasticsearch::api_protocol,
+  Integer                              $api_timeout             = $elasticsearch::api_timeout,
+  Boolean                              $compress                = true,
+  Optional[String]                     $chunk_size              = undef,
+  Optional[String]                     $max_restore_rate        = undef,
+  Optional[String]                     $max_snapshot_rate       = undef,
+  Optional[String]                     $repository_type         = undef,
+  Boolean                              $validate_tls            = $elasticsearch::validate_tls,
 ) {
 
   es_instance_conn_validator { "${name}-snapshot":

--- a/manifests/template.pp
+++ b/manifests/template.pp
@@ -53,18 +53,18 @@
 # @author Tyler Langlois <tyler.langlois@elastic.co>
 #
 define elasticsearch::template (
-  Enum['absent', 'present']       $ensure                  = 'present',
-  Optional[String]                $api_basic_auth_password = $elasticsearch::api_basic_auth_password,
-  Optional[String]                $api_basic_auth_username = $elasticsearch::api_basic_auth_username,
-  Optional[Stdlib::Absolutepath]  $api_ca_file             = $elasticsearch::api_ca_file,
-  Optional[Stdlib::Absolutepath]  $api_ca_path             = $elasticsearch::api_ca_path,
-  String                          $api_host                = $elasticsearch::api_host,
-  Integer[0, 65535]               $api_port                = $elasticsearch::api_port,
-  Enum['http', 'https']           $api_protocol            = $elasticsearch::api_protocol,
-  Integer                         $api_timeout             = $elasticsearch::api_timeout,
-  Optional[Variant[String, Hash]] $content                 = undef,
-  Optional[String]                $source                  = undef,
-  Boolean                         $validate_tls            = $elasticsearch::validate_tls,
+  Enum['absent', 'present']            $ensure                  = 'present',
+  Optional[Variant[String, Sensitive]] $api_basic_auth_password = $elasticsearch::api_basic_auth_password,
+  Optional[String]                     $api_basic_auth_username = $elasticsearch::api_basic_auth_username,
+  Optional[Stdlib::Absolutepath]       $api_ca_file             = $elasticsearch::api_ca_file,
+  Optional[Stdlib::Absolutepath]       $api_ca_path             = $elasticsearch::api_ca_path,
+  String                               $api_host                = $elasticsearch::api_host,
+  Integer[0, 65535]                    $api_port                = $elasticsearch::api_port,
+  Enum['http', 'https']                $api_protocol            = $elasticsearch::api_protocol,
+  Integer                              $api_timeout             = $elasticsearch::api_timeout,
+  Optional[Variant[String, Hash]]      $content                 = undef,
+  Optional[String]                     $source                  = undef,
+  Boolean                              $validate_tls            = $elasticsearch::validate_tls,
 ) {
   if $content =~ String {
     $_content = parsejson($content)

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -12,7 +12,10 @@
 #
 # @param password
 #   Password for the given user. A plaintext password will be managed
-#   with the esusers utility and requires a refresh to update, while
+#   with the esusers utility and requires a refresh to update.
+#
+# @param password_hash
+#   Password_hash for the given user.
 #   a hashed password from the esusers utility will be managed manually
 #   in the uses file.
 #
@@ -22,19 +25,20 @@
 # @author Tyler Langlois <tyler.langlois@elastic.co>
 #
 define elasticsearch::user (
-  String                    $password,
-  Enum['absent', 'present'] $ensure = 'present',
-  Array                     $roles  = [],
+  Optional[Variant[String, Sensitive]] $password,
+  Optional[Variant[String, Sensitive]] $password_hash,
+  Enum['absent', 'present']            $ensure = 'present',
+  Array                                $roles  = [],
 ) {
   if $elasticsearch::security_plugin == undef {
     fail("\"${elasticsearch::security_plugin}\" required")
   }
 
-  if $password =~ /^\$2a\$/ {
+  if $password_hash {
     elasticsearch_user_file { $name:
-      ensure          => $ensure,
-      configdir       => $elasticsearch::configdir,
-      hashed_password => $password,
+      ensure    => $ensure,
+      configdir => $elasticsearch::configdir,
+      password  => $password_hash,
     }
   } else {
     elasticsearch_user { $name:


### PR DESCRIPTION
…ash.

Password_hash has been added to prevent unwrapping Sensitive
data_types.

<!-- The following list of checkboxes are the prerequisites for getting your contribution accepted. Please check them as they are completed. -->

Pull request acceptance prerequisites:

- [ ] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [ ] Rebased/up-to-date with base branch
- [ ] Tests pass
- [ ] Updated CHANGELOG.md with patch notes (if necessary)
- [ ] Updated CONTRIBUTORS (if attribution is requested)
